### PR TITLE
[PDK-571] Implement variant

### DIFF
--- a/include/vccc/__variant/bad_variant_access.hpp
+++ b/include/vccc/__variant/bad_variant_access.hpp
@@ -1,0 +1,29 @@
+//
+// Created by YongGyu Lee on 11/3/23.
+//
+
+#ifndef VCCC_VARIANT_BAD_VARIANT_ACCESS_HPP
+#define VCCC_VARIANT_BAD_VARIANT_ACCESS_HPP
+
+#include <exception>
+
+namespace vccc {
+
+/// @addtogroup variant
+/// @{
+
+class bad_variant_access : public std::exception {
+ public:
+  bad_variant_access() noexcept = default;
+  bad_variant_access(const bad_variant_access&) noexcept = default;
+
+  const char* what() const noexcept override {
+    return "vccc::variant: Bad variant access";
+  }
+};
+
+/// @}
+
+} // namespace vccc
+
+#endif // VCCC_VARIANT_BAD_VARIANT_ACCESS_HPP

--- a/include/vccc/__variant/hash.hpp
+++ b/include/vccc/__variant/hash.hpp
@@ -1,0 +1,57 @@
+//
+// Created by YongGyu Lee on 02/01/24.
+//
+
+#ifndef VCCC_VARIANT_HASH_HPP
+#define VCCC_VARIANT_HASH_HPP
+
+#include <functional>
+
+#include "vccc/__functional/hash_array.hpp"
+#include "vccc/__variant/variant.hpp"
+#include "vccc/__variant/variant_npos.hpp"
+#include "vccc/__type_traits/conjunction.hpp"
+#include "vccc/__type_traits/is_invocable.hpp"
+#include "vccc/__type_traits/remove_cvref.hpp"
+
+/// @addtogroup variant
+/// @{
+
+namespace vccc {
+namespace detail {
+
+struct variant_hash_visitor {
+  template<typename T, std::size_t I>
+  constexpr std::size_t operator()(const T& x, in_place_index_t<I>) const {
+    return vccc::FNV_1a(std::hash<T>{}(x), I);
+  }
+
+  template<typename T>
+  constexpr std::size_t operator()(const T& x, in_place_index_t<variant_npos>) const {
+    return 0;
+  }
+};
+
+template<typename Variant, bool Hashable /* false */>
+struct variant_hash {};
+
+template<typename Variant>
+struct variant_hash<Variant, true> {
+  std::size_t operator()(const Variant& var) const {
+    return variant_raw_visit(var.index(), var._base().union_, variant_hash_visitor{});
+  }
+};
+
+} // namespace detail
+} // namespace vccc
+
+template<typename... Ts>
+struct std::hash<vccc::variant<Ts...>>
+    : vccc::detail::variant_hash<
+        vccc::variant<Ts...>,
+        vccc::conjunction<vccc::is_invocable<std::hash<Ts>, const vccc::remove_cvref_t<Ts>&>...>::value
+      > {};
+
+/// @}
+
+#endif // VCCC_VARIANT_HASH_HPP

--- a/include/vccc/__variant/holds_alternative.hpp
+++ b/include/vccc/__variant/holds_alternative.hpp
@@ -1,0 +1,35 @@
+//
+// Created by yonggyulee on 2/4/24.
+//
+
+#ifndef VCCC_VARIANTS_HOLDS_ALTERNATIVE_HPP
+#define VCCC_VARIANTS_HOLDS_ALTERNATIVE_HPP
+
+#include <type_traits>
+
+#include "vccc/__utility/type_sequence.hpp"
+#include "vccc/__variant/variant.hpp"
+
+namespace vccc {
+namespace detail {
+
+template<typename T>
+struct variant_holds_alternative_visitor {
+  template<typename U, std::size_t I>
+  constexpr bool operator()(const U&, in_place_index_t<I>) const {
+    return I != variant_npos && std::is_same<T, U>::value;
+  }
+};
+
+} // namespace detail
+
+template<typename T, typename... Types, std::enable_if_t<
+    (type_sequence<Types...>::template count<T> == 1)
+, int> = 0>
+constexpr bool holds_alternative(const variant<Types...>& v) noexcept {
+  return detail::variant_raw_visit(v.index(), v._base().union_, detail::variant_holds_alternative_visitor<T>{});
+}
+
+} // namespace vccc
+
+#endif // VCCC_VARIANTS_HOLDS_ALTERNATIVE_HPP

--- a/include/vccc/__variant/monostate.hpp
+++ b/include/vccc/__variant/monostate.hpp
@@ -1,0 +1,37 @@
+//
+// Created by YongGyu Lee on 11/3/23.
+//
+
+#ifndef VCCC_VARIANT_MONOSTATE_HPP
+#define VCCC_VARIANT_MONOSTATE_HPP
+
+#include <functional>
+
+/// @addtogroup variant
+/// @{
+
+namespace vccc {
+
+
+struct monostate {};
+
+constexpr bool operator==(monostate, monostate) noexcept { return true; }
+constexpr bool operator!=(monostate, monostate) noexcept { return false; }
+constexpr bool operator< (monostate, monostate) noexcept { return false; }
+constexpr bool operator> (monostate, monostate) noexcept { return false; }
+constexpr bool operator<=(monostate, monostate) noexcept { return true; }
+constexpr bool operator>=(monostate, monostate) noexcept { return true; }
+
+
+} // namespace vccc
+
+template<>
+struct std::hash<::vccc::monostate> {
+  std::size_t operator()(const ::vccc::monostate&) const noexcept {
+    return 1998;
+  }
+};
+
+/// @}
+
+#endif // VCCC_VARIANT_MONOSTATE_HPP

--- a/include/vccc/__variant/variant.hpp
+++ b/include/vccc/__variant/variant.hpp
@@ -1,0 +1,915 @@
+//
+// Created by YongGyu Lee on 10/27/23.
+//
+
+#ifndef VCCC_VARIANT_VARIANT_HPP
+#define VCCC_VARIANT_VARIANT_HPP
+
+#include <cassert>
+#include <new>
+#include <type_traits>
+
+#include "vccc/__concepts/different_from.hpp"
+#include "vccc/__concepts/equality_comparable.hpp"
+#include "vccc/__concepts/totally_ordered.hpp"
+#include "vccc/__core/constexpr.hpp"
+#include "vccc/__functional/equal_to.hpp"
+#include "vccc/__functional/not_equal_to.hpp"
+#include "vccc/__functional/greater.hpp"
+#include "vccc/__functional/greater_equal.hpp"
+#include "vccc/__functional/invoke.hpp"
+#include "vccc/__functional/less.hpp"
+#include "vccc/__functional/less_equal.hpp"
+#include "vccc/__memory/addressof.hpp"
+#include "vccc/__type_traits/bool_constant.hpp"
+#include "vccc/__type_traits/conjunction.hpp"
+#include "vccc/__type_traits/core/control_special.hpp"
+#include "vccc/__type_traits/disjunction.hpp"
+#include "vccc/__type_traits/is_list_initializable.hpp"
+#include "vccc/__type_traits/is_specialization.hpp"
+#include "vccc/__type_traits/is_swappable.hpp"
+#include "vccc/__type_traits/negation.hpp"
+#include "vccc/__type_traits/remove_cvref.hpp"
+#include "vccc/__type_traits/type_identity.hpp"
+#include "vccc/__utility/type_sequence.hpp"
+#include "vccc/__utility/in_place.hpp"
+#include "vccc/__variant/bad_variant_access.hpp"
+#include "vccc/__variant/monostate.hpp"
+#include "vccc/__variant/variant_alternative.hpp"
+#include "vccc/__variant/variant_npos.hpp"
+
+namespace vccc {
+
+/// @addtogroup variant
+/// @{
+
+/**
+ * @brief a type-safe discriminated union
+ *
+ * The class template std::variant represents a type-safe union. An instance of std::variant at
+ * any given time either holds a value of one of its alternative types, or in the case of
+ * error - no value (this state is hard to achieve, see valueless_by_exception).
+ *
+ * As with unions, if a variant holds a value of some object type T, the object representation
+ * of T is allocated directly within the object representation of the variant itself. Variant
+ * is not allowed to allocate additional (dynamic) memory.
+ *
+ * A variant is not permitted to hold references, arrays, or the type `void`. Empty variants ar
+ * also ill-formed (vccc::variant<vccc::monostate> can be used instead).
+ *
+ * A variant is permitted to hold the same type more than once, and to hold differently
+ * cv-qualified versions of the same type.
+ *
+ * Consistent with the behavior of unions during aggregate initialization, a default-constructed
+ * variant holds a value of its first alternative, unless that alternative is not
+ * default-constructible (in which case the variant is not default-constructible either).
+ * The helper class vccc::monostate can be used to make such variants default-constructible.
+ *
+ * @tparam Types
+ */
+template<typename... Types>
+class variant;
+
+namespace detail {
+
+template<typename T>
+struct index_value;
+template<std::size_t I>
+struct index_value<in_place_index_t<I>> : std::integral_constant<std::size_t, I> {};
+
+template<bool IsTriviallyDestructible, typename... Types>
+struct union_wrapper_t {};
+
+template<typename... Types>
+using union_wrapper = union_wrapper_t<conjunction<std::is_trivially_destructible<Types>...>::value, Types...>;
+
+template<typename T, typename... Types>
+struct union_wrapper_t<true, T, Types...> {
+  constexpr union_wrapper_t() noexcept {}
+
+  template<typename ...U>
+  constexpr explicit union_wrapper_t(in_place_index_t<0>, U&&... args)
+      noexcept(std::is_nothrow_constructible<T, U...>::value)
+      : head_(std::forward<U>(args)...) {}
+
+  template<std::size_t I, typename ...U>
+  constexpr explicit union_wrapper_t(in_place_index_t<I>, U&&... args)
+      noexcept(std::is_nothrow_constructible<union_wrapper<Types...>, in_place_index_t<I - 1>, U...>::value)
+      : tail_(in_place_index<I - 1>, std::forward<U>(args)...) {}
+
+  static constexpr std::size_t size = sizeof...(Types) + 1;
+
+  constexpr       T&  get()       & noexcept { return head_; }
+  constexpr const T&  get()  const& noexcept { return head_; }
+  constexpr       T&& get()      && noexcept { return std::move(head_); }
+  constexpr const T&& get() const&& noexcept { return std::move(head_); }
+
+  union {
+    T head_;
+    union_wrapper<Types...> tail_;
+  };
+};
+
+template<typename T, typename... Types>
+struct union_wrapper_t<false, T, Types...> {
+  constexpr union_wrapper_t() noexcept {}
+
+  template<typename ...U>
+  constexpr explicit union_wrapper_t(in_place_index_t<0>, U&&... args)
+      noexcept(std::is_nothrow_constructible<T, U...>::value)
+      : head_(std::forward<U>(args)...) {}
+
+  template<std::size_t I, typename ...U>
+  constexpr explicit union_wrapper_t(in_place_index_t<I>, U&&... args)
+      noexcept(std::is_nothrow_constructible<union_wrapper<Types...>, in_place_index_t<I - 1>, U...>::value)
+      : tail_(in_place_index_t<I - 1>{}, std::forward<U>(args)...) {}
+
+  static constexpr std::size_t size = sizeof...(Types) + 1;
+
+  VCCC_CONSTEXPR_AFTER_CXX20 ~union_wrapper_t() noexcept {}
+
+  constexpr union_wrapper_t(const union_wrapper_t&) = default;
+  constexpr union_wrapper_t(union_wrapper_t&&) = default;
+  constexpr union_wrapper_t& operator=(const union_wrapper_t&) = default;
+  constexpr union_wrapper_t& operator=(union_wrapper_t&&) = default;
+
+  constexpr       T&  get()       & noexcept { return head_; }
+  constexpr const T&  get()  const& noexcept { return head_; }
+  constexpr       T&& get()      && noexcept { return std::move(head_); }
+  constexpr const T&& get() const&& noexcept { return std::move(head_); }
+
+  union {
+    T head_;
+    union_wrapper<Types...> tail_;
+  };
+};
+
+template<typename Union> constexpr decltype(auto) variant_raw_get(Union&& u, in_place_index_t<0>) noexcept { return std::forward<Union>(u).get(); }
+template<typename Union> constexpr decltype(auto) variant_raw_get(Union&& u, in_place_index_t<1>) noexcept { return std::forward<Union>(u).tail_.get(); }
+template<typename Union> constexpr decltype(auto) variant_raw_get(Union&& u, in_place_index_t<2>) noexcept { return std::forward<Union>(u).tail_.tail_.get(); }
+template<typename Union> constexpr decltype(auto) variant_raw_get(Union&& u, in_place_index_t<3>) noexcept { return std::forward<Union>(u).tail_.tail_.tail_.get(); }
+template<typename Union> constexpr decltype(auto) variant_raw_get(Union&& u, in_place_index_t<4>) noexcept { return std::forward<Union>(u).tail_.tail_.tail_.tail_.get(); }
+template<typename Union> constexpr decltype(auto) variant_raw_get(Union&& u, in_place_index_t<5>) noexcept { return std::forward<Union>(u).tail_.tail_.tail_.tail_.tail_.get(); }
+template<typename Union> constexpr decltype(auto) variant_raw_get(Union&& u, in_place_index_t<6>) noexcept { return std::forward<Union>(u).tail_.tail_.tail_.tail_.tail_.tail_.get(); }
+template<typename Union> constexpr decltype(auto) variant_raw_get(Union&& u, in_place_index_t<7>) noexcept { return std::forward<Union>(u).tail_.tail_.tail_.tail_.tail_.tail_.tail_.get(); }
+template<typename Union> constexpr decltype(auto) variant_raw_get(Union&& u, in_place_index_t<8>) noexcept { return std::forward<Union>(u).tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.get(); }
+template<typename Union> constexpr decltype(auto) variant_raw_get(Union&& u, in_place_index_t<9>) noexcept { return std::forward<Union>(u).tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.get(); }
+template<typename Union> constexpr decltype(auto) variant_raw_get(Union&& u, in_place_index_t<10>) noexcept { return std::forward<Union>(u).tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.get(); }
+template<typename Union> constexpr decltype(auto) variant_raw_get(Union&& u, in_place_index_t<11>) noexcept { return std::forward<Union>(u).tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.get(); }
+template<typename Union> constexpr decltype(auto) variant_raw_get(Union&& u, in_place_index_t<12>) noexcept { return std::forward<Union>(u).tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.get(); }
+template<typename Union> constexpr decltype(auto) variant_raw_get(Union&& u, in_place_index_t<13>) noexcept { return std::forward<Union>(u).tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.get(); }
+template<typename Union> constexpr decltype(auto) variant_raw_get(Union&& u, in_place_index_t<14>) noexcept { return std::forward<Union>(u).tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.get(); }
+template<typename Union> constexpr decltype(auto) variant_raw_get(Union&& u, in_place_index_t<15>) noexcept { return std::forward<Union>(u).tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.get(); }
+
+template<typename Union, std::size_t I>
+constexpr decltype(auto) variant_raw_get(Union&& u, in_place_index_t<I>) {
+  return variant_raw_get(
+      std::forward<decltype(
+          std::forward<Union>(u).tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_)>(
+          std::forward<Union>(u).tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_
+      ),
+      in_place_index<I - 16>
+  );
+}
+
+// visiting npos
+template<typename Union, typename F, typename... Args>
+constexpr decltype(auto) variant_raw_visit_impl2(Union&& u, F&& func, in_place_index_t<0>, Args&&... args) {
+  return vccc::invoke(std::forward<F>(func), std::forward<Union>(u), in_place_index<variant_npos>, std::forward<Args>(args)...);
+}
+
+template<std::size_t I, typename Union, typename F, typename... Args>
+constexpr decltype(auto) variant_raw_visit_impl2(Union&& u, F&& func, in_place_index_t<I>, Args&&... args) {
+  return vccc::invoke(
+      std::forward<F>(func),
+      variant_raw_get(std::forward<Union>(u), in_place_index<I - 1>),
+      in_place_index<I - 1>,
+      std::forward<Args>(args)...
+  );
+}
+
+template<std::size_t Base, typename Union, typename F, typename... Args>
+constexpr decltype(auto) variant_raw_visit_recurse(std::size_t i, Union&& u, F&& func, in_place_index_t<Base>, std::true_type, Args&&... args);
+template<std::size_t Base, typename Union, typename F, typename... Args>
+constexpr decltype(auto) variant_raw_visit_recurse(std::size_t i, Union&& u, F&& func, in_place_index_t<Base>, std::false_type, Args&&... args) {
+  // unreachable
+  return variant_raw_visit_impl2(std::forward<Union>(u), std::forward<F>(func), in_place_index<0>, std::forward<Args>(args)...);
+}
+
+template<std::size_t Base, typename Union, typename F, typename... Args>
+constexpr decltype(auto) variant_raw_visit_impl(std::size_t i, Union&& u, F&& func, Args&&... args) {
+  switch (i) {
+    case 0: return variant_raw_visit_impl2(std::forward<Union>(u), std::forward<F>(func), in_place_index<(Base + 0 <= remove_cvref_t<Union>::size ? Base + 0 : 0)>, std::forward<Args>(args)...);
+    case 1: return variant_raw_visit_impl2(std::forward<Union>(u), std::forward<F>(func), in_place_index<(Base + 1 <= remove_cvref_t<Union>::size ? Base + 1 : 0)>, std::forward<Args>(args)...);
+    case 2: return variant_raw_visit_impl2(std::forward<Union>(u), std::forward<F>(func), in_place_index<(Base + 2 <= remove_cvref_t<Union>::size ? Base + 2 : 0)>, std::forward<Args>(args)...);
+    case 3: return variant_raw_visit_impl2(std::forward<Union>(u), std::forward<F>(func), in_place_index<(Base + 3 <= remove_cvref_t<Union>::size ? Base + 3 : 0)>, std::forward<Args>(args)...);
+    case 4: return variant_raw_visit_impl2(std::forward<Union>(u), std::forward<F>(func), in_place_index<(Base + 4 <= remove_cvref_t<Union>::size ? Base + 4 : 0)>, std::forward<Args>(args)...);
+    case 5: return variant_raw_visit_impl2(std::forward<Union>(u), std::forward<F>(func), in_place_index<(Base + 5 <= remove_cvref_t<Union>::size ? Base + 5 : 0)>, std::forward<Args>(args)...);
+    case 6: return variant_raw_visit_impl2(std::forward<Union>(u), std::forward<F>(func), in_place_index<(Base + 6 <= remove_cvref_t<Union>::size ? Base + 6 : 0)>, std::forward<Args>(args)...);
+    case 7: return variant_raw_visit_impl2(std::forward<Union>(u), std::forward<F>(func), in_place_index<(Base + 7 <= remove_cvref_t<Union>::size ? Base + 7 : 0)>, std::forward<Args>(args)...);
+    case 8: return variant_raw_visit_impl2(std::forward<Union>(u), std::forward<F>(func), in_place_index<(Base + 8 <= remove_cvref_t<Union>::size ? Base + 8 : 0)>, std::forward<Args>(args)...);
+    case 9: return variant_raw_visit_impl2(std::forward<Union>(u), std::forward<F>(func), in_place_index<(Base + 9 <= remove_cvref_t<Union>::size ? Base + 9 : 0)>, std::forward<Args>(args)...);
+    case 10: return variant_raw_visit_impl2(std::forward<Union>(u), std::forward<F>(func), in_place_index<(Base + 10 <= remove_cvref_t<Union>::size ? Base + 10 : 0)>, std::forward<Args>(args)...);
+    case 11: return variant_raw_visit_impl2(std::forward<Union>(u), std::forward<F>(func), in_place_index<(Base + 11 <= remove_cvref_t<Union>::size ? Base + 11 : 0)>, std::forward<Args>(args)...);
+    case 12: return variant_raw_visit_impl2(std::forward<Union>(u), std::forward<F>(func), in_place_index<(Base + 12 <= remove_cvref_t<Union>::size ? Base + 12 : 0)>, std::forward<Args>(args)...);
+    case 13: return variant_raw_visit_impl2(std::forward<Union>(u), std::forward<F>(func), in_place_index<(Base + 13 <= remove_cvref_t<Union>::size ? Base + 13 : 0)>, std::forward<Args>(args)...);
+    case 14: return variant_raw_visit_impl2(std::forward<Union>(u), std::forward<F>(func), in_place_index<(Base + 14 <= remove_cvref_t<Union>::size ? Base + 14 : 0)>, std::forward<Args>(args)...);
+    case 15: return variant_raw_visit_impl2(std::forward<Union>(u), std::forward<F>(func), in_place_index<(Base + 15 <= remove_cvref_t<Union>::size ? Base + 15 : 0)>, std::forward<Args>(args)...);
+    default:
+      return variant_raw_visit_recurse(
+          i - 16, std::forward<Union>(u), std::forward<F>(func),
+          in_place_index<Base + 16>,
+          bool_constant<(Base + 16 <= remove_cvref_t<Union>::size)>{},
+          std::forward<Args>(args)...);
+  }
+}
+
+template<std::size_t Base, typename Union, typename F, typename... Args>
+constexpr decltype(auto) variant_raw_visit_recurse(std::size_t i, Union&& u, F&& func, in_place_index_t<Base>, std::true_type, Args&&... args) {
+  return variant_raw_visit_impl<Base>(
+      i - 16,
+      std::forward<decltype(
+          std::forward<Union>(u).tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_)>(
+          std::forward<Union>(u).tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_),
+      std::forward<F>(func),
+      std::forward<Args>(args)...
+  );
+}
+
+template<typename Union, typename F, typename... Args>
+constexpr decltype(auto) variant_raw_visit(std::size_t i, Union&& u, F&& func, Args&&... args) {
+  // Move npos to 0 to avoid infinite switch recursion
+  return variant_raw_visit_impl<0>(i + 1, std::forward<Union>(u), std::forward<F>(func), std::forward<Args>(args)...);
+}
+
+template<typename... Types>
+struct variant_base;
+
+template<typename... Types>
+struct variant_ctor_raw_visitor {
+  variant_base<Types...>& base;
+
+  template<typename T, std::size_t I>
+  VCCC_ADDRESSOF_CONSTEXPR void operator()(T&& value, in_place_index_t<I>) {
+    using U = remove_cvref_t<type_sequence_element_type_t<I, type_sequence<Types...>>>;
+    ::new(vccc::addressof(variant_raw_get(base.union_, in_place_index<I>))) U(std::forward<T>(value));
+    base.index_ = I;
+  }
+
+  template<typename T>
+  constexpr void operator()(T&&, in_place_index_t<variant_npos>) {
+    base.index_ = variant_npos;
+  }
+};
+
+template<typename... Types>
+struct variant_assign_raw_visitor {
+  variant_base<Types...>& base;
+
+  template<typename T, std::size_t I>
+  VCCC_ADDRESSOF_CONSTEXPR void copy_assign_different(T& value, in_place_index_t<I>, std::true_type /* direct construct */) {
+    base.reset();
+    using U = remove_cvref_t<type_sequence_element_type_t<I, type_sequence<Types...>>>;
+    ::new(vccc::addressof(variant_raw_get(base.union_, in_place_index<I>))) U(value);
+  }
+
+  template<typename T, std::size_t I>
+  VCCC_ADDRESSOF_CONSTEXPR void copy_assign_different(T& value, in_place_index_t<I>, std::false_type /* direct construct */) {
+    auto temp = value;
+    base.reset();
+    using U = remove_cvref_t<type_sequence_element_type_t<I, type_sequence<Types...>>>;
+    ::new(vccc::addressof(variant_raw_get(base.union_, in_place_index<I>))) U(std::move(temp));
+  }
+
+  template<typename T, std::size_t I>
+  VCCC_ADDRESSOF_CONSTEXPR void assign_different(T&& value, in_place_index_t<I>) {
+    base.reset();
+    using U = remove_cvref_t<type_sequence_element_type_t<I, type_sequence<Types...>>>;
+    ::new(vccc::addressof(variant_raw_get(base.union_, in_place_index<I>))) U(std::forward<T>(value));
+  }
+
+  template<typename T, std::size_t I>
+  constexpr void assign_different(T& value, in_place_index_t<I>) {
+    copy_assign_different(value, in_place_index<I>,
+        disjunction<
+            std::is_nothrow_copy_constructible<remove_cvref_t<T>>,
+            negation< std::is_nothrow_move_constructible<remove_cvref_t<T>> >
+        >{});
+  }
+
+  template<typename T, std::size_t I>
+  constexpr void operator()(T&& value, in_place_index_t<I>) {
+    if (base.index_ == I) {
+      variant_raw_get(base.union_, in_place_index<I>) = std::forward<T>(value);
+    } else {
+      assign_different(std::forward<T>(value), in_place_index<I>);
+      base.index_ = I;
+    }
+  }
+
+  template<typename T>
+  constexpr void operator()(T&&, in_place_index_t<variant_npos>) {
+    base.reset();
+  }
+};
+
+template<typename F, bool Const, typename... Types>
+struct variant_op_visitor {
+  using base_type = std::conditional_t<Const, const variant_base<Types...>, variant_base<Types...>>;
+  base_type& thiz;
+
+  template<typename T, std::size_t I>
+  constexpr bool operator()(const T& y, in_place_index_t<I>) {
+    return F{}(variant_raw_get(thiz.union_, in_place_index<I>), y);
+  }
+
+  template<typename T>
+  constexpr bool operator()(const T&, in_place_index_t<variant_npos>) {
+    // unreachable
+    assert(((void)"Invalid access", false));
+    return false;
+  }
+};
+
+template<typename... Types>
+struct variant_base {
+  VCCC_CONSTEXPR_AFTER_CXX20 variant_base()
+      : union_{}, index_{variant_npos} {}
+
+  template<typename... U, std::size_t I>
+  constexpr explicit variant_base(in_place_index_t<I>, U&&... args)
+      : union_(in_place_index<I>, std::forward<U>(args)...), index_(I) {}
+
+  constexpr void construct_from(const variant_base& other) {
+    variant_raw_visit(other.index_, other.union_, variant_ctor_raw_visitor<Types...>{*this});
+  }
+  constexpr void construct_from(variant_base&& other)
+      noexcept(conjunction<std::is_nothrow_move_constructible<Types>...>::value) {
+    variant_raw_visit(other.index_, std::move(other.union_), variant_ctor_raw_visitor<Types...>{*this});
+  }
+
+  constexpr void assign_from(const variant_base& other) {
+    variant_raw_visit(other.index_, other.union_, variant_assign_raw_visitor<Types...>{*this});
+  }
+  constexpr void assign_from(variant_base&& other)
+      noexcept(conjunction<
+          std::is_nothrow_move_constructible<Types>...,
+          std::is_nothrow_move_assignable<Types>...
+        >::value) {
+    variant_raw_visit(other.index_, std::move(other.union_), variant_assign_raw_visitor<Types...>{*this});
+  }
+
+  VCCC_CONSTEXPR_AFTER_CXX20 void destroy_unchecked() {
+    variant_raw_visit(index_, union_, [](auto& x, auto) {
+        using T = remove_cvref_t<decltype(x)>;
+        x.~T();
+    });
+  }
+
+  template<typename Tj, typename T, std::size_t I>
+  VCCC_CONSTEXPR_AFTER_CXX20 void assign_different(T&& t, in_place_index_t<I>, std::true_type) {
+    emplace<I>(std::forward<T>(t));
+  }
+
+  template<typename Tj, typename T, std::size_t I>
+  VCCC_CONSTEXPR_AFTER_CXX20 void assign_different(T&& t, in_place_index_t<I>, std::false_type) {
+    emplace<I>(Tj(std::forward<T>(t)));
+  }
+
+  template<typename T, std::size_t I>
+  VCCC_CONSTEXPR_AFTER_CXX20 void assign(T&& t, std::integral_constant<std::size_t, I>) {
+    if (index_ == I) {
+      variant_raw_get(union_, in_place_index<I>) = std::forward<T>(t);
+    } else {
+      using Tj = type_sequence_element_type_t<I, type_sequence<Types...>>;
+      assign_different<Tj>(std::forward<T>(t), in_place_index<I>,
+          disjunction< std::is_nothrow_constructible<Tj, T>, negation< std::is_nothrow_move_constructible<Tj> > >{});
+    }
+  }
+
+  template<std::size_t I, typename... Args>
+  VCCC_CONSTEXPR_AFTER_CXX20 type_sequence_element_type_t<I, type_sequence<Types...>>&
+  emplace(Args&&... args) {
+    reset();
+    return emplace_valueless<I>(std::forward<Args>(args)...);
+  }
+
+  template<std::size_t I, typename... Args>
+  VCCC_CONSTEXPR_AFTER_CXX20 type_sequence_element_type_t<I, type_sequence<Types...>>&
+  emplace_valueless(Args&&... args) {
+    using U = remove_cvref_t<type_sequence_element_type_t<I, type_sequence<Types...>>>;
+    auto& elem = variant_raw_get(union_, in_place_index<I>);
+    ::new(vccc::addressof(elem)) U(std::forward<Args>(args)...);
+    index_ = I;
+    return elem;
+  }
+
+  template<std::size_t I>
+  struct swapper_inner {
+    variant_base& thiz;
+    variant_base& other;
+
+    // I <-> I
+    template<typename T, std::size_t J, std::enable_if_t<(J != variant_npos && J == I), int> = 0>
+    void operator()(T& y, in_place_index_t<J>) {
+      using std::swap;
+      T& x = variant_raw_get(thiz.union_, in_place_index<I>);
+      swap(x, y);
+    }
+
+    // I <-> J
+    template<typename U, std::size_t J, std::enable_if_t<(J != variant_npos && J != I && I != variant_npos), int> = 0>
+    void operator()(U& y, in_place_index_t<J>) {
+      auto x = std::move(variant_raw_get(thiz.union_, in_place_index<I>));
+      thiz.reset(in_place_index<I>);
+      thiz.template emplace_valueless<J>(std::move(y));
+      other.reset(in_place_index<J>);
+      other.template emplace_valueless<I>(std::move(x));
+    }
+
+    // valuelesss <-> J
+    template<typename U, std::size_t J, std::enable_if_t<(J != variant_npos && I == variant_npos), int> = 0>
+    void operator()(U& y, in_place_index_t<J>) {
+      thiz.template emplace_valueless<J>(std::move(y));
+      other.reset(in_place_index<J>);
+    }
+
+    // I <-> valueless
+    template<typename U, std::size_t J, std::enable_if_t<(J == variant_npos && J != I), int> = 0>
+    void operator()(U&, in_place_index_t<J>) {
+      auto& x = variant_raw_get(thiz.union_, in_place_index<I>);
+      other.template emplace_valueless<I>(std::move(x));
+      thiz.reset(in_place_index<I>);
+    }
+
+    // valueless <-> valueless
+    template<typename U, std::size_t J, std::enable_if_t<(J == variant_npos && J == I), int> = 0>
+    void operator()(U&, in_place_index_t<J>) {}
+  };
+
+  void swap_base_impl(variant_base& rhs, std::true_type /* trivial */) {
+    using std::swap;
+    swap(*this, rhs);
+  }
+
+  void swap_base_impl(variant_base& rhs, std::false_type /* trivial */) {
+    variant_raw_visit(index_, union_, [this, &rhs](auto& x, auto i) {
+      constexpr std::size_t I = index_value<decltype(i)>::value;
+      variant_raw_visit(rhs.index_, rhs.union_, swapper_inner<I>{*this, rhs});
+    });
+  }
+
+  void swap_base(variant_base& rhs) {
+    swap_base_impl(rhs, conjunction<std::is_trivial<Types>...>{});
+  }
+
+  void reset() {
+    if (index_ != variant_npos) {
+      destroy_unchecked();
+      index_ = variant_npos;
+    }
+  }
+
+  template<std::size_t I>
+  void reset(in_place_index_t<I>) {
+    auto& x = variant_raw_get(union_, in_place_index<I>);
+    using T = remove_cvref_t<decltype(x)>;
+    x.~T();
+  }
+
+  union_wrapper<Types...> union_;
+  std::size_t index_;
+};
+
+template<typename... Types>
+struct variant_nontrivial_dtor : variant_base<Types...> {
+  using base = variant_base<Types...>;
+  using base::base;
+
+  VCCC_CONSTEXPR_AFTER_CXX20 ~variant_nontrivial_dtor() {
+    if (base::index_ != variant_npos) {
+      base::destroy_unchecked();
+    }
+  }
+
+  variant_nontrivial_dtor() = default;
+  variant_nontrivial_dtor(const variant_nontrivial_dtor&) = default;
+  variant_nontrivial_dtor(variant_nontrivial_dtor&&) = default;
+  variant_nontrivial_dtor& operator=(const variant_nontrivial_dtor&) = default;
+  variant_nontrivial_dtor& operator=(variant_nontrivial_dtor&&) = default;
+};
+
+template<typename... Types>
+using variant_control_smf =
+    std::conditional_t<
+        conjunction<std::is_trivially_destructible<Types>...>::value,
+        control_special<variant_base<Types...>, Types...>,
+        control_special<variant_nontrivial_dtor<Types...>, Types...>
+    >;
+
+template<typename T> struct is_in_place_index : std::false_type {};
+template<std::size_t I> struct is_in_place_index<in_place_index_t<I>> : std::true_type {};
+
+// Get matching type for overload
+template<std::size_t I, typename...>
+struct variant_overload_t;
+
+template<std::size_t I, typename T>
+struct variant_overload_t<I, T> {
+  template<typename U, std::enable_if_t<is_copy_list_initializable<T, U>::value, int> = 0>
+  type_identity<T> test(T v);
+};
+
+template<std::size_t I, typename T, typename ...Ts>
+struct variant_overload_t<I, T, Ts...> : variant_overload_t<I + 1, Ts...> {
+  using base = variant_overload_t<I + 1, Ts...>;
+  using base::test;
+
+  template<typename U, std::enable_if_t<is_copy_list_initializable<T, U>::value, int> = 0>
+  type_identity<T> test(T v);
+};
+
+template<typename...T>
+using variant_overload = variant_overload_t<0, T...>;
+
+template<typename T, typename TypeSeq, typename = void>
+struct variant_has_overload : std::false_type {};
+
+template<typename T, typename ...Types>
+struct variant_has_overload<T, type_sequence<Types...>,
+    void_t<decltype(std::declval<variant_overload<Types...>>().template test<T>(std::declval<T>()))>>
+    : std::true_type
+{
+  using overload_type = typename decltype(
+      std::declval<variant_overload<Types...>>().template test<T>(std::declval<T>())
+  )::type;
+};
+
+template<typename T, typename TypeSeq>
+using variant_overload_type = typename variant_has_overload<T, TypeSeq>::overload_type;
+
+template<typename T, typename TypeSeq>
+using variant_overload_type_index = type_sequence_type_index<variant_overload_type<T, TypeSeq>, TypeSeq>;
+
+template<typename T, typename TypeSeq, bool = variant_has_overload<T, TypeSeq>::value /* false */>
+struct variant_has_unique_overload : std::false_type {};
+
+template<typename T, typename TypeSeq>
+struct variant_has_unique_overload<T, TypeSeq, true>
+    : bool_constant<type_sequence_type_count<variant_overload_type<T, TypeSeq>, TypeSeq>::value == 1> {};
+
+template<typename T, typename TypeSeq, bool = variant_has_unique_overload<T, TypeSeq>::value>
+struct variant_assign_check : std::false_type {};
+template<typename T, typename TypeSeq>
+struct variant_assign_check<T, TypeSeq, true> :
+    conjunction<
+        std::is_assignable<variant_overload_type<T, TypeSeq>&, T>,
+        std::is_constructible<variant_overload_type<T, TypeSeq>, T>
+    > {};
+
+/// @}
+
+} // namespace detail
+
+template<typename... Types>
+class variant : private detail::variant_control_smf<Types...> {
+  using base = detail::variant_control_smf<Types...>;
+  using TypeSeq = type_sequence<Types...>;
+
+ public:
+  static_assert(sizeof...(Types) > 0, "Variant must not be empty");
+  static_assert(disjunction<std::is_array<Types>...>::value == false, "Type must not be an array");
+  static_assert(disjunction<std::is_reference<Types>...>::value == false, "Type must not be a reference");
+  static_assert(disjunction<std::is_void<Types>...>::value == false, "Type must not be a void");
+
+  template<typename Dummy = void, std::enable_if_t<conjunction<std::is_void<Dummy>,
+      std::is_default_constructible<type_sequence_element_type_t<0, TypeSeq>>
+  >::value, int> = 0>
+  constexpr variant()
+      noexcept(std::is_nothrow_default_constructible<type_sequence_element_type_t<0, TypeSeq>>::value)
+      : base(in_place_index<0>) {}
+
+  template<typename T, std::enable_if_t<conjunction<
+      different_from<T, variant>,
+      negation< detail::is_in_place_index<remove_cvref_t<T>> >,
+      negation< is_specialization<remove_cvref_t<T>, in_place_type_t> >,
+      detail::variant_has_unique_overload<T, TypeSeq>
+  >::value, int> = 0>
+  constexpr variant(T&& t)
+      noexcept(std::is_nothrow_constructible<detail::variant_overload_type<T, TypeSeq>, T>::value)
+      : base(in_place_index<detail::variant_overload_type_index<T, TypeSeq>::value>, std::forward<T>(t)) {}
+
+  template<typename T, typename... Args, std::enable_if_t<conjunction<
+      bool_constant<( TypeSeq::template unique<T> )>,
+      std::is_constructible<T, Args...>
+  >::value, int> = 0>
+  constexpr explicit variant(in_place_type_t<T>, Args&&... args)
+      : base(in_place_index<type_sequence_type_index<T, TypeSeq>::value>, std::forward<Args>(args)...) {}
+
+  template<typename T, typename U, typename... Args, std::enable_if_t<conjunction<
+      bool_constant<( TypeSeq::template unique<T> )>,
+      std::is_constructible<T, std::initializer_list<U>&, Args...>
+  >::value, int> = 0>
+  constexpr explicit variant(in_place_type_t<T>, std::initializer_list<U> il, Args&&... args)
+      : base(in_place_index<TypeSeq::template index<T>>, il, std::forward<Args>(args)...) {}
+
+  template<std::size_t I, typename... Args, std::enable_if_t<conjunction<
+      bool_constant<( I < sizeof...(Types) )>,
+      std::is_constructible<type_sequence_element_type_t<I, TypeSeq>, Args...>
+  >::value, int> = 0>
+  constexpr explicit variant(in_place_index_t<I>, Args&&... args)
+      : base(in_place_index<I>, std::forward<Args>(args)...) {}
+
+  template<std::size_t I, typename U, typename... Args, std::enable_if_t<conjunction<
+      bool_constant<( I < sizeof...(Types) )>,
+      std::is_constructible<type_sequence_element_type_t<I, TypeSeq>, std::initializer_list<U>&, Args...>
+  >::value, int> = 0>
+  constexpr explicit variant(in_place_index_t<I>, std::initializer_list<U> il, Args&&... args)
+      : base(in_place_index<I>, il, std::forward<Args>(args)...) {}
+
+  template<typename T, std::enable_if_t<conjunction<
+      different_from<T, variant>,
+      detail::variant_assign_check<T, TypeSeq>
+  >::value, int> = 0>
+  constexpr variant& operator=(T&& t)
+      noexcept(conjunction<
+          std::is_nothrow_assignable<detail::variant_overload_type<T, TypeSeq>&, T>,
+          std::is_nothrow_constructible<detail::variant_overload_type<T, TypeSeq>, T> >::value)
+  {
+    base::assign(std::forward<T>(t), detail::variant_overload_type_index<T, TypeSeq>{});
+    return *this;
+  }
+
+  constexpr std::size_t index() const noexcept {
+    return base::index_;
+  }
+
+  constexpr bool valueless_by_exception() const noexcept {
+    return base::index_ == variant_npos;
+  }
+
+  template<typename T, typename... Args, std::enable_if_t<conjunction<
+      std::is_constructible<T, Args...>,
+      bool_constant<( TypeSeq::template unique<T> )>
+  >::value, int> = 0>
+  VCCC_CONSTEXPR_AFTER_CXX20 T& emplace(Args&&... args) {
+    return emplace<TypeSeq::template index<T>>(std::forward<Args>(args)...);
+  }
+
+  template<typename T, typename U, typename... Args, std::enable_if_t<conjunction<
+      std::is_constructible<T, std::initializer_list<U>&, Args...>,
+      bool_constant<( TypeSeq::template unique<T> )>
+  >::value, int> = 0>
+  VCCC_CONSTEXPR_AFTER_CXX20 T& emplace(std::initializer_list<U> il, Args&&... args) {
+    return emplace<TypeSeq::template index<T>>(il, std::forward<Args>(args)...);
+  }
+
+  template<std::size_t I, typename... Args, std::enable_if_t<
+      std::is_constructible<variant_alternative_t<I, variant>, Args...>
+  ::value, int> = 0>
+  VCCC_CONSTEXPR_AFTER_CXX20 variant_alternative_t<I, variant>& emplace(Args&&... args) {
+    return base::template emplace<I>(std::forward<Args>(args)...);
+  }
+
+  template<std::size_t I, typename T, typename... Args, std::enable_if_t<
+      std::is_constructible<variant_alternative_t<I, variant>, std::initializer_list<T>&, Args...>
+  ::value, int> = 0>
+  VCCC_CONSTEXPR_AFTER_CXX20 variant_alternative_t<I, variant>& emplace(std::initializer_list<T> il, Args&&... args) {
+    return base::template emplace<I>(il, std::forward<Args>(args)...);
+  }
+
+  constexpr void swap(variant& rhs)
+      noexcept(conjunction<std::is_nothrow_move_constructible<Types>..., is_nothrow_swappable<Types>... >::value)
+  {
+    base::swap_base(rhs);
+  }
+
+  template<typename Visitor>
+  constexpr decltype(auto) visit(Visitor&& vis) {
+    return visit_impl(std::forward<Visitor>(vis));
+  }
+
+  template<typename R, typename Visitor>
+  constexpr R visit(Visitor&& vis) {
+    return visit_r<R>(std::forward<Visitor>(vis), std::is_void<R>{});
+  }
+
+  detail::variant_base<Types...>& _base() & { return static_cast<detail::variant_base<Types...>&>(*this); }
+  detail::variant_base<Types...>&& _base() && { return static_cast<detail::variant_base<Types...>&&>(*this); }
+  const detail::variant_base<Types...>& _base() const & { return static_cast<const detail::variant_base<Types...>&>(*this); }
+  const detail::variant_base<Types...>&& _base() const && { return static_cast<const detail::variant_base<Types...>&&>(*this); }
+
+ private:
+  struct visitor_self {
+    template<typename T, std::size_t I, typename Visitor>
+    constexpr decltype(auto) operator()(T&& x, in_place_index_t<I>, Visitor&& vis) const {
+      return vccc::invoke(std::forward<Visitor>(vis), std::forward<T>(x));
+    }
+
+    template<typename Union, typename Visitor>
+    constexpr decltype(auto) operator()(Union&& u, in_place_index_t<variant_npos>, Visitor&& vis) const {
+      throw bad_variant_access{};
+      return vccc::invoke(std::forward<Visitor>(vis), std::forward<Union>(u).get());
+    }
+  };
+
+  template<typename Visitor>
+  constexpr decltype(auto) visit_impl(Visitor&& vis) {
+    return detail::variant_raw_visit(index(), base::union_, visitor_self{}, std::forward<Visitor>(vis));
+  }
+
+  template<typename R, typename Visitor>
+  constexpr void visit_r(Visitor&& vis, std::true_type /* is_void */) {
+    visit_impl(std::forward<Visitor>(vis));
+  }
+
+  template<typename R, typename Visitor>
+  constexpr R visit_r(Visitor&& vis, std::false_type /* is_void */) {
+    return static_cast<R>(visit_impl(std::forward<Visitor>(vis)));
+  }
+};
+
+template<std::size_t I, typename... Types>
+constexpr variant_alternative_t<I, variant<Types...>>&
+get(variant<Types...>& v) {
+  if (v.index() != I)
+    throw bad_variant_access{};
+  return detail::variant_raw_get(v._base().union_, in_place_index<I>);
+}
+
+template<std::size_t I, typename... Types>
+constexpr variant_alternative_t<I, variant<Types...>>&&
+get(variant<Types...>&& v) {
+  if (v.index() != I)
+    throw bad_variant_access{};
+  return std::move(detail::variant_raw_get(v._base().union_, in_place_index<I>));
+}
+
+template<std::size_t I, typename... Types>
+constexpr const variant_alternative_t<I, variant<Types...>>&
+get(const variant<Types...>& v) {
+  if (v.index() != I)
+    throw bad_variant_access{};
+  return detail::variant_raw_get(v._base().union_, in_place_index<I>);
+}
+
+template<std::size_t I, typename... Types>
+constexpr const variant_alternative_t<I, variant<Types...>>&&
+get(const variant<Types...>&& v) {
+  if (v.index() != I)
+    throw bad_variant_access{};
+  return std::move(detail::variant_raw_get(v._base().union_, in_place_index<I>));
+}
+
+template<typename T, typename... Types, std::enable_if_t<
+    (type_sequence_type_count<T, type_sequence<Types...>>::value == 1), int> = 0>
+constexpr T& get(variant<Types...>& v) {
+  return get<type_sequence_type_index<T, type_sequence<Types...>>::value>(v);
+}
+
+template<typename T, typename... Types, std::enable_if_t<
+    (type_sequence_type_count<T, type_sequence<Types...>>::value == 1), int> = 0>
+constexpr T&& get(variant<Types...>&& v) {
+  return std::move(get<type_sequence_type_index<T, type_sequence<Types...>>::value>(std::move(v)));
+}
+
+template<typename T, typename... Types, std::enable_if_t<
+    (type_sequence_type_count<T, type_sequence<Types...>>::value == 1), int> = 0>
+constexpr const T& get(const variant<Types...>& v) {
+  return get<type_sequence_type_index<T, type_sequence<Types...>>::value>(v);
+}
+
+template<typename T, typename... Types, std::enable_if_t<
+    (type_sequence_type_count<T, type_sequence<Types...>>::value == 1), int> = 0>
+constexpr const T&& get(const variant<Types...>&& v) {
+  return std::move(get<type_sequence_type_index<T, type_sequence<Types...>>::value>(std::move(v)));
+}
+
+template<std::size_t I, typename... Types>
+constexpr std::add_pointer_t<variant_alternative_t<I, variant<Types...>>>
+get_if(variant<Types...>* pv) noexcept {
+  if (pv->index() != I)
+    return nullptr;
+  return vccc::addressof(detail::variant_raw_get(pv->_base().union_, in_place_index<I>));
+}
+
+template<std::size_t I, typename... Types>
+constexpr std::add_pointer_t<const variant_alternative_t<I, variant<Types...>>>
+get_if(const variant<Types...>* pv) noexcept {
+  if (pv->index() != I)
+    return nullptr;
+  return vccc::addressof(detail::variant_raw_get(pv->_base().union_, in_place_index<I>));
+}
+
+template<typename T, typename... Types, std::enable_if_t<
+    (type_sequence_type_count<T, type_sequence<Types...>>::value == 1), int> = 0>
+constexpr std::add_pointer_t<T>
+get_if(variant<Types...>* pv) noexcept {
+  constexpr std::size_t I = type_sequence_type_index<T, type_sequence<Types...>>::value;
+  if (pv->index() != I)
+    return nullptr;
+  return vccc::addressof(detail::variant_raw_get(pv->_base().union_, in_place_index<I>));
+}
+
+template<typename T, typename... Types, std::enable_if_t<
+    (type_sequence_type_count<T, type_sequence<Types...>>::value == 1), int> = 0>
+constexpr std::add_pointer_t<const T>
+get_if(const variant<Types...>* pv) noexcept {
+  constexpr std::size_t I = type_sequence_type_index<T, type_sequence<Types...>>::value;
+  if (pv->index() != I)
+    return nullptr;
+  return vccc::addressof(detail::variant_raw_get(pv->_base().union_, in_place_index<I>));
+}
+
+template<typename... Types, std::enable_if_t<conjunction<equality_comparable<Types>...>::value, int> = 0>
+constexpr bool operator==(const variant<Types...>& v, const variant<Types...>& w) {
+  if (v.index() != w.index())
+    return false;
+  if (v.valueless_by_exception())
+    return true;
+  using visitor = detail::variant_op_visitor<ranges::equal_to, true, Types...>;
+  return detail::variant_raw_visit(w.index(), w._base().union_, visitor{v._base()});
+}
+
+template<typename... Types, std::enable_if_t<conjunction<equality_comparable<Types>...>::value, int> = 0>
+constexpr bool operator!=(const variant<Types...>& v, const variant<Types...>& w) {
+  if (v.index() != w.index())
+    return true;
+  if (v.valueless_by_exception())
+    return false;
+  using visitor = detail::variant_op_visitor<ranges::not_equal_to, true, Types...>;
+  return detail::variant_raw_visit(w.index(), w._base().union_, visitor{v._base()});
+}
+
+template<typename... Types, std::enable_if_t<conjunction<totally_ordered<Types>...>::value, int> = 0>
+constexpr bool operator<(const variant<Types...>& v, const variant<Types...>& w) {
+  if (w.valueless_by_exception())
+    return false;
+  if (v.valueless_by_exception())
+    return true;
+  if (v.index() != w.index()) {
+    return v.index() < w.index();
+  }
+
+  using visitor = detail::variant_op_visitor<ranges::less, true, Types...>;
+  return detail::variant_raw_visit(w.index(), w._base().union_, visitor{v._base()});
+}
+
+template<typename... Types, std::enable_if_t<conjunction<totally_ordered<Types>...>::value, int> = 0>
+constexpr bool operator>(const variant<Types...>& v, const variant<Types...>& w) {
+  if (v.valueless_by_exception())
+    return false;
+  if (w.valueless_by_exception())
+    return true;
+  if (v.index() != w.index()) {
+    return v.index() > w.index();
+  }
+
+  using visitor = detail::variant_op_visitor<ranges::greater, true, Types...>;
+  return detail::variant_raw_visit(w.index(), w._base().union_, visitor{v._base()});
+}
+
+template<typename... Types, std::enable_if_t<conjunction<totally_ordered<Types>...>::value, int> = 0>
+constexpr bool operator<=(const variant<Types...>& v, const variant<Types...>& w) {
+  if (v.valueless_by_exception())
+    return true;
+  if (w.valueless_by_exception())
+    return false;
+  if (v.index() != w.index()) {
+    return v.index() < w.index();
+  }
+
+  using visitor = detail::variant_op_visitor<ranges::less_equal, true, Types...>;
+  return detail::variant_raw_visit(w.index(), w._base().union_, visitor{v._base()});
+}
+
+template<typename... Types, std::enable_if_t<conjunction<totally_ordered<Types>...>::value, int> = 0>
+constexpr bool operator>=(const variant<Types...>& v, const variant<Types...>& w) {
+  if (w.valueless_by_exception())
+    return true;
+  if (v.valueless_by_exception())
+    return false;
+  if (v.index() != w.index()) {
+    return v.index() > w.index();
+  }
+
+  using visitor = detail::variant_op_visitor<ranges::greater_equal, true, Types...>;
+  return detail::variant_raw_visit(w.index(), w._base().union_, visitor{v._base()});
+}
+
+template <typename... Types>
+constexpr std::enable_if_t<conjunction<std::is_move_constructible<Types>..., is_swappable<Types>...>::value>
+swap(variant<Types...>& lhs, variant<Types...>& rhs) noexcept(noexcept(lhs.swap(rhs))) {
+  lhs.swap(rhs);
+}
+
+} // namespace vccc
+
+namespace std {
+
+using ::vccc::get;
+using ::vccc::get_if;
+
+} // namespace std
+
+#endif // VCCC_VARIANT_VARIANT_HPP

--- a/include/vccc/__variant/variant_alternative.hpp
+++ b/include/vccc/__variant/variant_alternative.hpp
@@ -1,0 +1,45 @@
+//
+// Created by YongGyu Lee on 11/3/23.
+//
+
+#ifndef VCCC_VARIANT_VARIANT_ALTERNATIVE_HPP
+#define VCCC_VARIANT_VARIANT_ALTERNATIVE_HPP
+
+#include <cstddef>
+#include <type_traits>
+
+#include "vccc/__utility/type_sequence.hpp"
+
+namespace vccc {
+
+/// @addtogroup variant
+/// @{
+/// @defgroup variant_variant_alternative__class variant_alternative
+/// @{
+
+/// @cond ignored
+template<typename... Types>
+class variant;
+/// @endcond
+
+template<std::size_t, typename T>
+struct variant_alternative;
+
+template <std::size_t I, class T>
+using variant_alternative_t = typename variant_alternative<I, T>::type;
+
+template<std::size_t I, typename T>
+struct variant_alternative<I, const T> {
+  using type = std::add_const_t<variant_alternative_t<I, T>>;
+};
+
+template<std::size_t I, typename... Types>
+struct variant_alternative<I, variant<Types...>>
+    : type_sequence_element_type<I, type_sequence<Types...>> {};
+
+/// @}
+/// @}
+
+} // namespace vccc
+
+#endif // VCCC_VARIANT_VARIANT_ALTERNATIVE_HPP

--- a/include/vccc/__variant/variant_npos.hpp
+++ b/include/vccc/__variant/variant_npos.hpp
@@ -1,0 +1,23 @@
+//
+// Created by YongGyu Lee on 11/3/23.
+//
+
+#ifndef VCCC_VARIANT_VARIANT_NPOS_HPP
+#define VCCC_VARIANT_VARIANT_NPOS_HPP
+
+#include <cstddef>
+
+#include "vccc/__core/inline_or_static.hpp"
+
+namespace vccc {
+
+/// @addtogroup variant
+/// @{
+
+VCCC_INLINE_OR_STATIC constexpr std::size_t variant_npos = -1;
+
+/// @}
+
+} // namespace vccc
+
+#endif // VCCC_VARIANT_VARIANT_NPOS_HPP

--- a/include/vccc/__variant/variant_size.hpp
+++ b/include/vccc/__variant/variant_size.hpp
@@ -1,0 +1,38 @@
+//
+// Created by YongGyu Lee on 02/01/24.
+//
+
+#ifndef VCCC_VARIANT_VARIANT_SIZE_HPP
+#define VCCC_VARIANT_VARIANT_SIZE_HPP
+
+#include <type_traits>
+
+#include "vccc/__core/inline_or_static.hpp"
+
+namespace vccc {
+
+/// @addtogroup variant
+/// @{
+
+/// @cond ignored
+template<typename... T>
+class variant;
+/// @endcond
+
+template<typename T>
+struct variant_size;
+
+template<typename... Ts>
+struct variant_size<variant<Ts...>> : std::integral_constant<std::size_t, sizeof...(Ts)> {};
+
+template<typename T>
+struct variant_size<const T> : std::integral_constant<std::size_t, variant_size<T>::value> {};
+
+template<typename T>
+VCCC_INLINE_OR_STATIC constexpr std::size_t variant_size_v = variant_size<T>::value;
+
+/// @}
+
+} // namespace vccc
+
+#endif // VCCC_VARIANT_VARIANT_SIZE_HPP

--- a/include/vccc/__variant/visit.hpp
+++ b/include/vccc/__variant/visit.hpp
@@ -1,0 +1,114 @@
+//
+// Created by yonggyulee on 1/31/24.
+//
+
+#ifndef VCCC_VARIANT_VISIT_HPP
+#define VCCC_VARIANT_VISIT_HPP
+
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "vccc/__core/inline_or_static.hpp"
+#include "vccc/__functional/invoke.hpp"
+#include "vccc/__type_traits/conjunction.hpp"
+#include "vccc/__type_traits/is_invocable.hpp"
+#include "vccc/__variant/variant.hpp"
+#include "vccc/__variant/variant_alternative.hpp"
+
+namespace vccc {
+namespace detail {
+
+template<std::size_t Cursor, typename R>
+struct visitor_global {
+  template<typename T, std::size_t J, typename Vis, std::size_t... I, typename... Variants>
+  constexpr R operator()(T&&, in_place_index_t<J>, Vis&& vis, std::index_sequence<I...>, Variants&&... vars) const {
+    return visitor_global<Cursor - 1, R>{}.visit(
+        std::forward<Vis>(vis), std::index_sequence<I..., J>{}, std::forward<Variants>(vars)...);
+  }
+
+  template<typename U, typename Vis, std::size_t... I, typename... Variants>
+  constexpr R operator()(U&&, in_place_index_t<variant_npos>, Vis&& vis, std::index_sequence<I...>, Variants&&... vars) const {
+    throw bad_variant_access{};
+    return visitor_global<Cursor - 1, R>{}.visit(
+        std::forward<Vis>(vis), std::index_sequence<I..., 0>{}, std::forward<Variants>(vars)...);
+  }
+
+  template<typename Vis, std::size_t...I, typename... Variants>
+  constexpr R visit(Vis&& vis, std::index_sequence<I...>, Variants&&... vars) const {
+    auto&& var = std::get<Cursor - 1>(std::forward_as_tuple(std::forward<Variants>(vars)...));
+    return variant_raw_visit(
+        var.index(), std::forward<decltype(var._base().union_)>(var._base().union_), *this,
+        std::forward<Vis>(vis), std::index_sequence<I...>{}, std::forward<Variants>(vars)...);
+  }
+};
+
+template<typename R>
+struct visitor_global<0, R> {
+  template<typename Vis, std::size_t...I, typename... Variants>
+  constexpr R visit(Vis&& vis, std::index_sequence<I...>,  Variants&&... vars) const {
+    return vccc::invoke_r<R>(
+        std::forward<Vis>(vis),
+        std::forward<decltype(variant_raw_get(vars._base().union_, in_place_index<I>))>(
+            variant_raw_get(vars._base().union_, in_place_index<I>))...
+    );
+  }
+};
+
+struct as_variant_niebloid {
+  template<typename... Ts>
+  constexpr variant<Ts...>& operator()(variant<Ts...>& var) const noexcept { return var; }
+
+  template<typename... Ts>
+  constexpr const variant<Ts...>& operator()(const variant<Ts...>& var) const noexcept { return var;}
+
+  template<typename... Ts>
+  constexpr variant<Ts...>&& operator()(variant<Ts...>&& var) const noexcept { return std::move(var); }
+
+  template<typename... Ts>
+  constexpr const variant<Ts...>&& operator()(const variant<Ts...>&& var) const noexcept { return std::move(var); }
+};
+
+VCCC_INLINE_OR_STATIC constexpr as_variant_niebloid as_variant{};
+
+template<typename Variant>
+using as_variant_t = invoke_result_t<as_variant_niebloid, Variant>;
+
+template<typename Visitor, typename... Variants>
+struct variant_visit_result {
+  using type = invoke_result_t<Visitor, decltype(get<0>(std::declval<Variants>()))...>;
+};
+
+template<typename Visitor, typename... Variants>
+using variant_visit_result_t = typename variant_visit_result<Visitor, as_variant_t<Variants>...>::type;
+
+} // namespace detail
+
+/// @addtogroup variant
+/// @{
+
+template<typename R, typename Visitor, typename... Variants, std::enable_if_t<conjunction<
+    is_invocable<detail::as_variant_niebloid, Variants>...
+>::value, int> = 0>
+constexpr R visit(Visitor&& vis, Variants&&... vars) {
+  return detail::visitor_global<sizeof...(Variants), R>{}.visit(
+      std::forward<Visitor>(vis),
+      std::index_sequence<>{},
+      detail::as_variant(std::forward<Variants>(vars))...
+  );
+}
+
+template<typename Visitor, typename... Variants, std::enable_if_t<conjunction<
+    is_invocable<detail::as_variant_niebloid, Variants>...
+>::value, int> = 0>
+constexpr decltype(auto)
+visit(Visitor&& vis, Variants&&... vars) {
+  using R = detail::variant_visit_result_t<Visitor, detail::as_variant_t<Variants>...>;
+  return visit<R>(std::forward<Visitor>(vis), std::forward<Variants>(vars)...);
+}
+
+/// @}
+
+} // namespace vccc
+
+#endif // VCCC_VARIANT_VISIT_HPP

--- a/include/vccc/variant.hpp
+++ b/include/vccc/variant.hpp
@@ -1,0 +1,26 @@
+//
+// Created by YongGyu Lee on 10/27/23.
+//
+
+#ifndef VCCC_VARIANT_HPP
+#define VCCC_VARIANT_HPP
+
+#include "vccc/__variant/bad_variant_access.hpp"
+#include "vccc/__variant/hash.hpp"
+#include "vccc/__variant/holds_alternative.hpp"
+#include "vccc/__variant/monostate.hpp"
+#include "vccc/__variant/variant.hpp"
+#include "vccc/__variant/variant_alternative.hpp"
+#include "vccc/__variant/variant_npos.hpp"
+#include "vccc/__variant/variant_size.hpp"
+#include "vccc/__variant/visit.hpp"
+
+/**
+@defgroup variant variant
+@brief Implementation of STL header [`<variant>`](https://en.cppreference.com/w/cpp/header/variant)
+
+See [\<variant\> at cppreference.com](https://en.cppreference.com/w/cpp/header/tuple)
+for more information.
+*/
+
+#endif // VCCC_VARIANT_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ VCCC_TEST(span_test span_test.cpp VCCC)
 VCCC_TEST(string_view_test string_view_test.cpp VCCC)
 VCCC_TEST(tuple_test tuple_test.cpp VCCC)
 VCCC_TEST(type_traits_test type_traits_test.cpp VCCC)
+VCCC_TEST(variant_test variant_test.cpp VCCC)
 
 VCCC_TEST_ONE_CXX(directory_test directory_test.cc 17 VCCC)
 VCCC_TEST(log_test log_test.cpp VCCC)

--- a/test/variant_test.cpp
+++ b/test/variant_test.cpp
@@ -1,0 +1,444 @@
+//
+// Created by YongGyu Lee on 2021/02/03.
+//
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <type_traits>
+
+#include "vccc/algorithm.hpp"
+#include "vccc/functional.hpp"
+#include "vccc/ranges.hpp"
+#include "vccc/string_view.hpp"
+#include "vccc/variant.hpp"
+#include "test_core.hpp"
+
+namespace vccc {
+namespace {
+
+int x_dtor = 0;
+int y_dtor = 0;
+
+template<typename... Ts>
+struct overloaded_t;
+
+template<typename T>
+struct overloaded_t<T> : T {
+  overloaded_t(T x) : T(std::move(x)) {}
+  using T::operator();
+};
+template<typename T, typename... Ts>
+struct overloaded_t<T, Ts...> : T, overloaded_t<Ts...> {
+  overloaded_t(T x, Ts... y)
+      : T(std::move(x)), overloaded_t<Ts...>(std::move(y)...) {}
+
+  using T::operator();
+  using overloaded_t<Ts...>::operator();
+};
+
+template<class... Ts>
+auto overloaded(Ts&&... t) {
+  return overloaded_t<std::remove_reference_t<Ts>...>(std::forward<Ts>(t)...);
+}
+
+int Test() {
+  INIT_TEST("vccc::variant")
+
+  { // constructor
+    using vector_t = std::vector<int>;
+
+    variant<int, std::string> var0;
+    TEST_ENSURES(holds_alternative<int>(var0) &&
+                 var0.index() == 0 &&
+                 std::get<int>(var0) == 0);
+
+    // initializes first alternative with std::string{"STR"};
+    variant<std::string, int> var1{"STR"};
+    TEST_ENSURES(var1.index() == 0);
+    TEST_ENSURES(std::get<std::string>(var1) == "STR");
+
+    // initializes second alternative with int == 42;
+    variant<std::string, int> var2{42};
+    TEST_ENSURES(holds_alternative<int>(var2));
+    TEST_ENSURES(std::get<int>(var2) == 42);
+
+    // initializes first alternative with std::string{4, 'A'};
+    variant<std::string, vector_t, float> var3{vccc::in_place_type<std::string>, 4, 'A'};
+    TEST_ENSURES(var3.index() == 0);
+    TEST_ENSURES(std::get<std::string>(var3) == "AAAA");
+
+    // initializes second alternative with std::vector{1,2,3,4,5};
+    variant<std::string, vector_t, char> var4{vccc::in_place_type<vector_t>, {1, 2, 3, 4, 5}};
+    TEST_ENSURES(var4.index() == 1);
+    TEST_ENSURES(ranges::equal(std::get<vector_t>(var4), views::iota(1) | views::take(5)));
+
+    // initializes first alternative with std::string{"ABCDE", 3};
+    variant<std::string, vector_t, bool> var5 {vccc::in_place_index<0>, "ABCDE", 3};
+    TEST_ENSURES(var5.index() == 0);
+    TEST_ENSURES(std::get<std::string>(var5) == "ABC");
+
+    // initializes second alternative with std::vector(4, 42);
+    variant<std::string, vector_t, char> var6 {vccc::in_place_index<1>, 4, 42};
+    TEST_ENSURES(holds_alternative<vector_t>(var6));
+    TEST_ENSURES(ranges::equal(std::get<vector_t>(var6), views::repeat(42, 4) ));
+  }
+
+  { // destructor
+    struct X { ~X() { ++x_dtor; } };
+    struct Y { ~Y() { ++y_dtor; } };
+    TEST_ENSURES(x_dtor == 0 && y_dtor == 0);
+
+    { variant<X,Y> var; }
+    TEST_ENSURES(x_dtor == 1 && y_dtor == 0);
+
+    { variant<X,Y> var{ in_place_index_t<1>{} }; } // constructs var(Y)
+    TEST_ENSURES(x_dtor == 1 && y_dtor == 1);
+  }
+
+  { // operator=
+    struct string_visitor {
+      string_view operator()(int x) const { return {}; }
+      string_view operator()(const std::string& x) const { return x; }
+    };
+    struct int_visitor {
+      int operator()(int x) const { return x; }
+      int operator()(const std::string& x) const { return -9999; }
+    };
+
+    variant<int, std::string> a{2017}, b{"CppCon"};
+
+    TEST_ENSURES(a.visit(int_visitor{}) == 2017);
+    TEST_ENSURES(b.visit(string_visitor{}) == "CppCon");
+
+    TEST_ENSURES(vccc::visit(int_visitor{}, a) == 2017);
+    TEST_ENSURES(vccc::visit(string_visitor{}, b) == "CppCon");
+
+    a = b;
+    TEST_ENSURES(a == b);
+    TEST_ENSURES(a.visit(string_visitor{}) == "CppCon");
+    TEST_ENSURES(b.visit(string_visitor{}) == "CppCon");
+
+    a = std::move(b);
+    TEST_ENSURES(a != b);
+    TEST_ENSURES(a.visit(string_visitor{}) == "CppCon");
+    TEST_ENSURES(b.visit(string_visitor{}).empty());
+
+    a = 2019;
+    TEST_ENSURES(a.visit(int_visitor{}) == 2019);
+
+    std::string s{"CppNow"};
+    a = std::move(s);
+    TEST_ENSURES(a.visit(string_visitor{}) == "CppNow");
+  }
+
+  { // index
+    variant<int, std::string> v = "abc";
+
+    TEST_ENSURES(v.index() == 1);
+    v = {};
+    TEST_ENSURES(v.index() == 0);
+  }
+
+  { // valueless_by_exception
+    struct Demo {
+      Demo(int) {}
+      Demo(const Demo&) { throw std::domain_error("copy ctor"); }
+      Demo& operator= (const Demo&) = default;
+    };
+
+    variant<std::string, Demo> var{"str"};
+    TEST_ENSURES(var.index() == 0);
+    TEST_ENSURES(std::get<0>(var) == "str");
+    TEST_ENSURES(var.valueless_by_exception() == false);
+
+    try {
+      var = Demo{555};
+      TEST_ENSURES(false);
+    } catch (const std::domain_error& ex) {
+      std::cout << "1) Exception: " << ex.what() << '\n';
+    }
+    TEST_ENSURES(var.index() == variant_npos);
+    TEST_ENSURES(var.valueless_by_exception() == true);
+
+    // Now the var is "valueless" which is an invalid state caused
+    // by an exception raised in the process of type-changing assignment.
+
+    try {
+      std::get<1>(var);
+      TEST_ENSURES(false);
+    } catch (const bad_variant_access& ex) {
+      std::cout << "2) Exception: " << ex.what() << '\n';
+    }
+
+    var = "str2";
+    TEST_ENSURES(var.index() == 0);
+    TEST_ENSURES(std::get<0>(var) == "str2");
+    TEST_ENSURES(var.valueless_by_exception() == false);
+  }
+
+  { // emplace
+    variant<std::string> v1;
+    v1.emplace<0>("abc"); // OK
+    TEST_ENSURES(std::get<0>(v1) == "abc");
+
+    v1.emplace<std::string>("def"); // OK
+    TEST_ENSURES(std::get<0>(v1) == "def");
+
+    variant<std::string, std::string> v2;
+    v2.emplace<1>("ghi"); // OK
+    TEST_ENSURES(std::get<1>(v2) == "ghi");
+    // v2.emplace<std::string>("abc");
+
+  }
+
+  {
+    static_assert(std::is_constructible<variant<std::string>, decltype("abc")>::value, ""); // OK
+    static_assert(std::is_constructible<variant<std::string, std::string>, decltype("abc")>::value == false, ""); // ill-formed
+    static_assert(std::is_constructible<variant<std::string, const char*>, decltype("abc")>::value, ""); // OK, chooses const char*
+    TEST_ENSURES((variant<std::string, const char*>("abc").index() == 1));
+    TEST_ENSURES((variant<std::string, bool>("abc").index() == 0)); // OK, chooses string; bool is not a candidate
+    TEST_ENSURES((variant<float, long, double>{0}.index() == 1)); // OK, holds long
+  }
+
+  { // variant_alternative
+    using v = variant<int, float>;
+    static_assert(std::is_same<int,   variant_alternative_t<0, v>>::value, "");
+    static_assert(std::is_same<float, variant_alternative_t<1, v>>::value, "");
+    // cv-qualification on the variant type propagates to the extracted alternative type.
+    static_assert(std::is_same<const int, variant_alternative_t<0, const v>>::value, "");
+  }
+
+  { // swap
+    variant<int, std::string> v1{2}, v2{"abc"};
+    TEST_ENSURES(get<0>(v1) == 2);
+    TEST_ENSURES(get<1>(v2) == "abc");
+    v1.swap(v2);
+    TEST_ENSURES(get<1>(v1) == "abc");
+    TEST_ENSURES(get<0>(v2) == 2);
+  }
+
+  { // visit
+    using var_t = variant<int, long, double, std::string>;
+
+    std::vector<var_t> vec = {10, 15l, 1.5, "hello"};
+
+    for (auto& v: vec) {
+        // 1. void visitor, only called for side-effects (here, for I/O)
+        visit([](auto&& arg){ std::cout << arg; }, v);
+
+        // 2. value-returning visitor, demonstrates the idiom of returning another variant
+        var_t w = visit([](auto&& arg) -> var_t { return arg + arg; }, v);
+
+        // 3. type-matching visitor: a lambda that handles each type differently
+#if __cplusplus >= 201703L
+        std::cout << ". After doubling, variant holds ";
+        visit([](auto&& arg) {
+            using T = std::decay_t<decltype(arg)>;
+            if constexpr (std::is_same_v<T, int>)
+                std::cout << "int with value " << arg << '\n';
+            else if constexpr (std::is_same_v<T, long>)
+                std::cout << "long with value " << arg << '\n';
+            else if constexpr (std::is_same_v<T, double>)
+                std::cout << "double with value " << arg << '\n';
+            else if constexpr (std::is_same_v<T, std::string>)
+                std::cout << "std::string with value " << std::quoted(arg) << '\n';
+            else
+                static_assert(always_false<T>::value, "non-exhaustive visitor!");
+        }, w);
+#else
+      std::cout << '\n';
+#endif
+    }
+
+    std::stringstream ss;
+    for (auto& v: vec) {
+      // 4. another type-matching visitor: a class with 3 overloaded operator()'s
+      // Note: The `(auto arg)` template operator() will bind to `int` and `long`
+      //       in this case, but in its absence the `(double arg)` operator()
+      //       *will also* bind to `int` and `long` because both are implicitly
+      //       convertible to double. When using this form, care has to be taken
+      //       that implicit conversions are handled correctly.
+      visit(overloaded(
+          [&](auto arg) { ss << arg << ' '; },
+          [&](double arg) { ss << std::fixed << arg << ' '; },
+          [&](const std::string& arg) { ss << std::quoted(arg) << ' '; }
+      ), v);
+    }
+    TEST_ENSURES(ss.str() == R"(10 15 1.500000 "hello" )");
+  }
+
+  { // holds alternative
+    variant<int, std::string> v = "abc";
+    TEST_ENSURES(holds_alternative<int>(v) == false);
+    TEST_ENSURES(holds_alternative<std::string>(v) == true);
+  }
+
+  { // get
+    variant<int, float> v{12}, w;
+    TEST_ENSURES(std::get<int>(v) == 12);
+    w = std::get<int>(v);
+    TEST_ENSURES(std::get<int>(w) == 12);
+    w = std::get<0>(v); // same effect as the previous line
+    TEST_ENSURES(std::get<0>(w) == 12);
+
+    //  std::get<double>(v); // error: no double in [int, float]
+    //  std::get<3>(v);      // error: valid index values are 0 and 1
+
+    try {
+      w = 42.0f;
+      TEST_ENSURES(std::get<float>(w) == 42.0f);
+      w = 42;
+      std::cout << std::get<float>(w) << '\n'; // throws
+      TEST_ENSURES(false);
+    } catch (bad_variant_access const& ex) {
+      std::cout << ex.what() << ": w contained int, not float\n";
+    }
+  }
+
+  { // get_if
+    variant<int, float> v{12}, w{3.f};
+    TEST_ENSURES(get_if<int>(&v) != nullptr);
+    TEST_ENSURES(std::get_if<int>(&w) == nullptr);
+  }
+
+  { // monostate
+    struct S {
+      S(int i) : i(i) {}
+      int i;
+    };
+
+    variant<monostate, S> var;
+    TEST_ENSURES(var.index() == 0);
+
+    try {
+      std::get<S>(var); // throws! We need to assign a value
+      TEST_ENSURES(false);
+    } catch(const bad_variant_access& e) {
+      std::cout << e.what() << '\n';
+    }
+
+    var = 42;
+    TEST_ENSURES(std::get<S>(var).i == 42);
+
+    std::cout << "std::get: " << std::get<S>(var).i << '\n'
+              << "std::hash: " << std::hex << std::showbase
+              << std::hash<monostate>{}(monostate{}) << '\n';
+  }
+
+  {
+    using v = variant<int, float, std::string>;
+    v v1(1);
+    v v2(2.0f);
+    v v3("hello");
+
+    v2.swap(v3);
+    TEST_ENSURES(v2.index() == 2);
+    TEST_ENSURES(v3.index() == 1);
+  }
+
+  { // comparison operators
+    variant<int, std::string> v1, v2;
+
+    { // operator==
+      // by default v1 = 0, v2 = 0;
+      TEST_ENSURES(v1 == v2);
+      TEST_ENSURES(v1.index() == 0 && get<int>(v1) == 0);
+
+      v1 = v2 = 1;
+      TEST_ENSURES(v1 == v2);
+      TEST_ENSURES(v1.index() == 0 && get<int>(v1) == 1);
+
+      v2 = 2;
+      TEST_ENSURES((v1 == v2) == false);
+      TEST_ENSURES(v1.index() == 0 && get<int>(v1) == 1);
+      TEST_ENSURES(v2.index() == 0 && get<int>(v2) == 2);
+
+      v1 = "A";
+      TEST_ENSURES((v1 == v2) == false);
+      TEST_ENSURES(v1.index() == 1 && get<std::string>(v1) == "A");
+      TEST_ENSURES(v2.index() == 0 && get<int>(v2) == 2);
+
+      v2 = "B";
+      TEST_ENSURES(v1 != v2);
+      TEST_ENSURES(v1.index() == 1 && get<std::string>(v1) == "A");
+      TEST_ENSURES(v2.index() == 1 && get<std::string>(v2) == "B");
+
+      v2 = "A";
+      TEST_ENSURES(v1 == v2);
+      TEST_ENSURES(v1.index() == 1 && get<std::string>(v1) == "A");
+      TEST_ENSURES(v2.index() == 1 && get<std::string>(v2) == "A");
+    }
+
+    { // operator<
+
+      v1 = v2 = 1;
+      TEST_ENSURES((v1 < v2) == false);
+
+      v2 = 2;
+      TEST_ENSURES(v1 < v2);
+
+      v1 = 3;
+      TEST_ENSURES((v1 < v2) == false);
+
+      v1 = "A"; v2 = 1;
+      TEST_ENSURES((v1 < v2) == false);
+      TEST_ENSURES(v1.index() == 1 && v2.index() == 0);
+
+      v1 = 1; v2 = "A";
+      TEST_ENSURES(v1 < v2);
+      TEST_ENSURES(v1.index() == 0 && v2.index() == 1);
+
+      v1 = v2 = "A";
+      TEST_ENSURES((v1 < v2) == false);
+
+      v2 = "B";
+      TEST_ENSURES(v1 < v2);
+
+      v1 = "C";
+      TEST_ENSURES((v1 < v2) == false);
+    }
+
+    {
+      static_assert(equality_comparable_with<variant<int, std::string>, variant<int, std::string>>::value, "");
+      static_assert(equality_comparable_with<variant<int, std::string>, variant<std::string, int>>::value == false, "");
+    }
+  }
+
+  { // variant_size
+    static_assert(variant_size<variant<>>::value == 0, "");
+    static_assert(variant_size<variant<int>>::value == 1, "");
+    static_assert(variant_size<variant<int, int>>::value == 2, "");
+    static_assert(variant_size<variant<int, int, int>>::value == 3, "");
+    static_assert(variant_size<variant<int, float, double>>::value == 3, "");
+    static_assert(variant_size<variant<monostate, void>>::value == 2, "");
+    static_assert(variant_size<variant<const int, const float>>::value == 2, "");
+    // static_assert(variant_size<variant<variant<std::any>>>::value == 1);
+  }
+
+  { // hash
+    using Var = variant<int, int, int, std::string>;
+
+    Var var;
+    std::get<0>(var) = 2020;
+    std::cout << "get<0> = " << std::get<0>(var) << "\t" "# = " << std::hash<Var>{}(var) << '\n';
+
+    var.emplace<1>(2023);
+    std::cout << "get<1> = " << std::get<1>(var) << "\t" "# = " << std::hash<Var>{}(var) << '\n';
+
+    var.emplace<2>(2026);
+    std::cout << "get<2> = " << std::get<2>(var) << "\t" "# = " << std::hash<Var>{}(var) << '\n';
+
+    var = "C++";
+    std::cout << "get<3> = " << std::get<3>(var) << "\t" "# = " << std::hash<Var>{}(var) << '\n';
+  }
+
+  return TEST_RETURN_RESULT;
+}
+
+} // namespace
+} // namespace vccc
+
+int main() {
+  return ::vccc::Test();
+}


### PR DESCRIPTION
Add C++14 implementation of [`std::variant`](https://en.cppreference.com/w/cpp/utility/variant) required for implementing non-joining OneTBB calculators